### PR TITLE
Allow installing to $DESTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,10 @@ clean: rvrrpd-pw-clean
 	@cargo clean
 
 install: rvrrpd-pw-install
-	cp $(TARGET)/${BINARY} $(PREFIX)/sbin/rvrrpd
-	chmod 755 $(PREFIX)/sbin/rvrrpd
-	if [ ! -d "/etc/rvrrpd" ]; then \
-		mkdir /etc/rvrrpd; \
-	fi
+	[ ! -d "$(DESTDIR)$(PREFIX)/sbin" ] && mkdir -p "$(DESTDIR)$(PREFIX)/sbin"
+	cp $(TARGET)/${BINARY} $(DESTDIR)$(PREFIX)/sbin/rvrrpd
+	chmod 755 $(DESTDIR)$(PREFIX)/sbin/rvrrpd
+	[ ! -d "$(DESTDIR)/etc/rvrrpd" ] && mkdir -p "$(DESTDIR)/etc/rvrrpd"
 
 rvrrpd-pw:
 	cd utils/rvrrpd-pw && $(MAKE)

--- a/utils/rvrrpd-pw/Makefile
+++ b/utils/rvrrpd-pw/Makefile
@@ -15,7 +15,8 @@ clean:
 	@cargo clean
 
 install:
-	cp $(TARGET)/${BINARY} $(PREFIX)/bin/${BINARY}
-	chmod 755 $(PREFIX)/bin/rvrrpd-pw
+	[ ! -d "$(DESTDIR)$(PREFIX)/bin" ] && mkdir -p "$(DESTDIR)$(PREFIX)/bin"
+	cp $(TARGET)/${BINARY} $(DESTDIR)$(PREFIX)/bin/${BINARY}
+	chmod 755 $(DESTDIR)$(PREFIX)/bin/rvrrpd-pw
 
 .PHONY: main test check clean install


### PR DESCRIPTION
Staged Installs require a custom installation location.

This is helpful when packaging packages for release, as the tools need to have installable files "installed" to a separate clean subdirectory, from which they can then, well, be packaged.

`mkdir` calls are required to anticipate those subdirectories in the temporary root not yet existing. No folder structure necessarily exists there at the start of all this.

[GNU Coding Standard: 7.2.4 DESTDIR: Support for Staged Installs](https://www.gnu.org/prep/standards/html_node/DESTDIR.html)