### PR TITLE
Use `make -C dir` in favor of `cd dir && make`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,12 +24,12 @@ install: rvrrpd-pw-install
 	[ ! -d "$(DESTDIR)/etc/rvrrpd" ] && mkdir -p "$(DESTDIR)/etc/rvrrpd"
 
 rvrrpd-pw:
-	cd utils/rvrrpd-pw && $(MAKE)
+	$(MAKE) -C utils/rvrrpd-pw
 
 rvrrpd-pw-install:
-	cd utils/rvrrpd-pw && $(MAKE) install
+	$(MAKE) -C utils/rvrrpd-pw install
 
 rvrrpd-pw-clean:
-	cd utils/rvrrpd-pw && $(MAKE) clean
+	$(MAKE) -C utils/rvrrpd-pw clean
 
 .PHONY: main test docs check clean install


### PR DESCRIPTION
Make has an argument `-C` which allows one to avoid manually changing directories. Seems fitting here to use it, instead of the shuffling with `cd` on each line.