### PR TITLE
Set up `--version` output compliant to GNU

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 Lightweight, fast, and highly secure VRRP daemon
-Copyright (C) 2019-2021  Nicolas Chabbey
+Copyright (C) 2019-2021 Nicolas Chabbey
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/bin/rvrrpd.rs
+++ b/src/bin/rvrrpd.rs
@@ -139,14 +139,15 @@ fn parse_cli_opts(args: &[String]) -> Result<Config, Box<dyn Error>> {
 
 // print_version_info() function
 fn print_version_info() {
-    println!("{} {}
+    println!(
+        "{} {} {}
 
-Copyright (C) 2019-2021  Nicolas Chabbey.
-License GPLv3+: GNU GPL Version 3 or any later version <https://www.gnu.org/licenses/gpl-3.0.txt>.
-This program comes with ABSOLUTELY NO WARRANTY. This is free software,
-and you are welcome to redistribute it under certain conditions.
-
-Written by {}.", RVRRPD_NAME.to_lowercase(), RVRRPD_VERSION, RVRRPD_AUTHORS);
+Written by {}.",
+        RVRRPD_NAME.to_lowercase(),
+        RVRRPD_VERSION,
+        RVRRPD_COPYRIGHT_BLOCK,
+        RVRRPD_AUTHORS
+    );
 }
 
 // run() function

--- a/src/bin/rvrrpd.rs
+++ b/src/bin/rvrrpd.rs
@@ -139,7 +139,14 @@ fn parse_cli_opts(args: &[String]) -> Result<Config, Box<dyn Error>> {
 
 // print_version_info() function
 fn print_version_info() {
-    println!("{} v{} by {}", RVRRPD_NAME, RVRRPD_VERSION, RVRRPD_AUTHORS);
+    println!("{} {}
+
+Copyright (C) 2019-2021  Nicolas Chabbey.
+License GPLv3+: GNU GPL Version 3 or any later version <https://www.gnu.org/licenses/gpl-3.0.txt>.
+This program comes with ABSOLUTELY NO WARRANTY. This is free software,
+and you are welcome to redistribute it under certain conditions.
+
+Written by {}.", RVRRPD_NAME.to_lowercase(), RVRRPD_VERSION, RVRRPD_AUTHORS);
 }
 
 // run() function

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -10,6 +10,12 @@ pub const RVRRPD_BANNER: &str = r"
 | |   \  /  | | \ \| | \ \| |  | (_| |
 |_|    \/   |_|  \_\_|  \_\_|   \__,_|
 ";
+pub const RVRRPD_COPYRIGHT_BLOCK: &str = r"
+Copyright (C) 2019-2021 Nicolas Chabbey.
+License GPLv3+: GNU GPL Version 3 or any later version <https://www.gnu.org/licenses/gpl-3.0.txt>.
+This program comes with ABSOLUTELY NO WARRANTY. This is free software,
+and you are welcome to redistribute it under certain conditions.
+";
 pub const RVRRPD_DFLT_CFG_FILE: &str = "/etc/rvrrpd/rvrrpd.conf";
 pub const RVRRPD_DFLT_PIDFILE: &str = "/var/run/rvrrpd.pid";
 pub const RVRRPD_DFLT_WORKDIR: &str = "/tmp";

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -14,8 +14,7 @@ pub const RVRRPD_COPYRIGHT_BLOCK: &str = r"
 Copyright (C) 2019-2021 Nicolas Chabbey.
 License GPLv3+: GNU GPL Version 3 or any later version <https://www.gnu.org/licenses/gpl-3.0.txt>.
 This program comes with ABSOLUTELY NO WARRANTY. This is free software,
-and you are welcome to redistribute it under certain conditions.
-";
+and you are welcome to redistribute it under certain conditions.";
 pub const RVRRPD_DFLT_CFG_FILE: &str = "/etc/rvrrpd/rvrrpd.conf";
 pub const RVRRPD_DFLT_PIDFILE: &str = "/var/run/rvrrpd.pid";
 pub const RVRRPD_DFLT_WORKDIR: &str = "/tmp";

--- a/utils/rvrrpd-pw/src/main.rs
+++ b/utils/rvrrpd-pw/src/main.rs
@@ -7,7 +7,7 @@ use std::error::Error;
 use std::fmt;
 
 // clap
-use clap::{App, Arg};
+use clap::{App, Arg, crate_version};
 
 // rand
 use rand::prelude::Rng;
@@ -46,8 +46,16 @@ impl Error for MyError {
 
 // main() function
 fn main() {
-    let matches = App::new("rVRRPd password utility")
-        .version("v0.1.4")
+    let matches = App::new("rvrrpd-pw")
+        .version(crate_version!())
+        .long_version(concat!(crate_version!(), "
+
+Copyright (C) 2019-2021  Nicolas Chabbey.
+License GPLv3+: GNU GPL Version 3 or any later version <https://www.gnu.org/licenses/gpl-3.0.txt>.
+This program comes with ABSOLUTELY NO WARRANTY. This is free software,
+and you are welcome to redistribute it under certain conditions.
+
+Written by Nicolas Chabbey <eprom@toor.si>."))
         .author("Nicolas Chabbey <eprom@toor.si>")
         .about("Quick and easy password generation for rVRRPd")
         .arg(

--- a/utils/rvrrpd-pw/src/main.rs
+++ b/utils/rvrrpd-pw/src/main.rs
@@ -49,7 +49,6 @@ fn main() {
     let matches = App::new("rvrrpd-pw")
         .version(crate_version!())
         .long_version(concat!(crate_version!(), "
-
 Copyright (C) 2019-2021 Nicolas Chabbey.
 License GPLv3+: GNU GPL Version 3 or any later version <https://www.gnu.org/licenses/gpl-3.0.txt>.
 This program comes with ABSOLUTELY NO WARRANTY. This is free software,

--- a/utils/rvrrpd-pw/src/main.rs
+++ b/utils/rvrrpd-pw/src/main.rs
@@ -50,7 +50,7 @@ fn main() {
         .version(crate_version!())
         .long_version(concat!(crate_version!(), "
 
-Copyright (C) 2019-2021  Nicolas Chabbey.
+Copyright (C) 2019-2021 Nicolas Chabbey.
 License GPLv3+: GNU GPL Version 3 or any later version <https://www.gnu.org/licenses/gpl-3.0.txt>.
 This program comes with ABSOLUTELY NO WARRANTY. This is free software,
 and you are welcome to redistribute it under certain conditions.


### PR DESCRIPTION
There are automatic manual generation tools which use the `--version` output as to gather the executable name, version information, copyright and authorship information. You can try `cp --version` in your terminal for an example of this formatting. Now, `rvrrpd` and `rvrrpd-pw` also use the same output format of:

    executable x.y.z
    Copyright notice / license notice.

    "Written by" authorship notice.