### PR TITLE
Set up manual page generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ Cargo.lock
 
 # documentation
 docs/_build
+
+# auto-generated manpage
+rvrrpd.8.gz

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,11 @@ install: rvrrpd-pw-install
 	fi
 	cp $(TARGET)/${BINARY} $(DESTDIR)$(PREFIX)/sbin/${BINARY}
 	chmod 755 $(DESTDIR)$(PREFIX)/sbin/${BINARY}
+	if [ ! -d $(DESTDIR)$(PREFIX)/share/man/man8 ]; then \
+		mkdir -p $(DESTDIR)$(PREFIX)/share/man/man8; \
+	fi
 	cp ${BINARY}.8.gz $(DESTDIR)$(PREFIX)/share/man/man8/${BINARY}.8.gz
+	chmod 644 $(DESTDIR)$(PREFIX)/share/man/man8/${BINARY}.8.gz
 	if [ ! -d $(DESTDIR)/etc/rvrrpd ]; then \
 		mkdir -p $(DESTDIR)/etc/rvrrpd; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ TARGET = target/release
 BINARY = rvrrpd
 PREFIX = /usr
 
+all: main ${BINARY}.8.gz
+
 main: rvrrpd-pw
 	@cargo build --release
 
@@ -14,7 +16,11 @@ docs:
 check:
 	@cargo fmt --all -- --check
 
+${BINARY}.8.gz: main
+	help2man -N -s8 -n'lightweight, fast, and highly secure VRRP daemon' $(TARGET)/${BINARY} | gzip > $@
+
 clean: rvrrpd-pw-clean
+	rm -f ${BINARY}.8.gz
 	@cargo clean
 
 install: rvrrpd-pw-install
@@ -23,6 +29,7 @@ install: rvrrpd-pw-install
 	fi
 	cp $(TARGET)/${BINARY} $(DESTDIR)$(PREFIX)/sbin/${BINARY}
 	chmod 755 $(DESTDIR)$(PREFIX)/sbin/${BINARY}
+	cp ${BINARY}.8.gz $(DESTDIR)$(PREFIX)/share/man/man8/${BINARY}.8.gz
 	if [ ! -d $(DESTDIR)/etc/rvrrpd ]; then \
 		mkdir -p $(DESTDIR)/etc/rvrrpd; \
 	fi

--- a/docs/config/install.rst
+++ b/docs/config/install.rst
@@ -42,12 +42,13 @@ To build **rVRRPd** from source you must have several programs and libraries ins
    to build the project and its related dependencies (crates).
  * The `OpenSSL <https://www.openssl.org/>`_ development headers
  * The `Netlink Protocol Library Suite <https://www.infradead.org/~tgr/libnl/>`_ development headers *(Linux)*
+ * The `help2man <https://www.gnu.org/software/help2man/>`_ utility, to generate manual pages.
 
 On `Debian <https://www.debian.org>`_ and derivatives, all three libraries' headers files can be installed with the below command:
 
 .. code-block:: console
 
-    $ sudo apt-get install libnl-3-dev libnl-route-3-dev libssl-dev
+    $ sudo apt-get install libnl-3-dev libnl-route-3-dev libssl-dev help2man
 
 Cloning Source Repository
 ^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -111,12 +112,22 @@ paths by using the ``make install`` command (requires root privileges):
     fi
     cp target/release/rvrrpd-pw /usr/bin/rvrrpd-pw
     chmod 755 /usr/bin/rvrrpd-pw
+    if [ ! -d /usr/share/man/man1 ]; then \
+        mkdir -p /usr/share/man/man1; \
+    fi
+    cp rvrrpd-pw.1.gz /usr/share/man/man1/rvrrpd-pw.1.gz
+    chmod 644 /usr/share/man/man1/rvrrpd-pw.1.gz
     make[1]: Leaving directory 'utils/rvrrpd-pw'
     if [ ! -d /usr/sbin ]; then \
         mkdir -p /usr/sbin; \
     fi
     cp target/release/rvrrpd /usr/sbin/rvrrpd
     chmod 755 /usr/sbin/rvrrpd
+    if [ ! -d /usr/share/man/man8 ]; then \
+        mkdir -p /usr/share/man/man8; \
+    fi
+    cp rvrrpd.8.gz /usr/share/man/man8/rvrrpd.8.gz
+    chmod 644 /usr/share/man/man8/rvrrpd.8.gz
     if [ ! -d /etc/rvrrpd ]; then \
         mkdir -p /etc/rvrrpd; \
     fi

--- a/utils/rvrrpd-pw/.gitignore
+++ b/utils/rvrrpd-pw/.gitignore
@@ -11,3 +11,6 @@ Cargo.lock
 
 # local configuration files
 *.local.conf
+
+# auto-generated manpage
+rvrrpd-pw.1.gz

--- a/utils/rvrrpd-pw/Makefile
+++ b/utils/rvrrpd-pw/Makefile
@@ -2,6 +2,8 @@ TARGET = target/release
 BINARY = rvrrpd-pw
 PREFIX = /usr
 
+all: main ${BINARY}.1.gz
+
 main:
 	@cargo build --release
 
@@ -11,7 +13,11 @@ test:
 check:
 	@cargo fmt --all -- --check
 
+${BINARY}.1.gz: main
+	help2man -N -s1 -n'quick and easy password generation for rVRRPd' $(TARGET)/${BINARY} | gzip > $@
+
 clean:
+	rm -f ${BINARY}.1.gz
 	@cargo clean
 
 install:
@@ -20,5 +26,6 @@ install:
 	fi
 	cp $(TARGET)/${BINARY} $(DESTDIR)$(PREFIX)/bin/${BINARY}
 	chmod 755 $(DESTDIR)$(PREFIX)/bin/${BINARY}
+	cp ${BINARY}.1.gz $(DESTDIR)$(PREFIX)/share/man/man1/${BINARY}.1.gz
 
 .PHONY: main test check clean install

--- a/utils/rvrrpd-pw/Makefile
+++ b/utils/rvrrpd-pw/Makefile
@@ -22,7 +22,7 @@ clean:
 
 install:
 	if [ ! -d $(DESTDIR)$(PREFIX)/bin ]; then \
-		 mkdir -p $(DESTDIR)$(PREFIX)/bin; \
+		mkdir -p $(DESTDIR)$(PREFIX)/bin; \
 	fi
 	cp $(TARGET)/${BINARY} $(DESTDIR)$(PREFIX)/bin/${BINARY}
 	chmod 755 $(DESTDIR)$(PREFIX)/bin/${BINARY}

--- a/utils/rvrrpd-pw/Makefile
+++ b/utils/rvrrpd-pw/Makefile
@@ -26,6 +26,10 @@ install:
 	fi
 	cp $(TARGET)/${BINARY} $(DESTDIR)$(PREFIX)/bin/${BINARY}
 	chmod 755 $(DESTDIR)$(PREFIX)/bin/${BINARY}
+	if [ ! -d $(DESTDIR)$(PREFIX)/share/man/man1 ]; then \
+		mkdir -p $(DESTDIR)$(PREFIX)/share/man/man1; \
+	fi
 	cp ${BINARY}.1.gz $(DESTDIR)$(PREFIX)/share/man/man1/${BINARY}.1.gz
+	chmod 644 $(DESTDIR)$(PREFIX)/share/man/man1/${BINARY}.1.gz
 
 .PHONY: main test check clean install


### PR DESCRIPTION
For purposes of packaging the tooling, manual pages are a must.

The Makefile build steps have been adjusted to generate manpages using the `help2man` tool which executes the locally built executables with the `--help` and `--version` flags. The Makefile install steps have further been adjusted to place these generated manpages in the /usr/share/man directory by default.

This ensures documentation in manpages does not have to be maintained by hand separated from the codebase, and is instead automatically generated from the latest 'source of truth'.

When building locally without installation steps, you can use the command `man -l rvrrpd.8.gz` to just 'preview' the manpage.