### PR TITLE
Fix spelling of caught and occurred

### DIFF
--- a/src/bin/rvrrpd.rs
+++ b/src/bin/rvrrpd.rs
@@ -160,7 +160,7 @@ fn run(cfg: Config) -> Result<(), Box<dyn Error>> {
     // Listen to IP packets
     match listen_ip_pkts(&cfg) {
         Ok(_) => Ok(()),
-        Err(e) => Result::Err(Box::new(MyError(format!("A runtime error occured: {}", e)))),
+        Err(e) => Result::Err(Box::new(MyError(format!("A runtime error occurred: {}", e)))),
     }
 }
 

--- a/src/fsm.rs
+++ b/src/fsm.rs
@@ -379,7 +379,7 @@ pub fn fsm_run(
                             debug,
                             DEBUG_LEVEL_EXTENSIVE,
                             DEBUG_SRC_FSM,
-                            "unexpected event catched in Init state".to_string(),
+                            "unexpected event caught in Init state".to_string(),
                         );
                         continue;
                     }

--- a/src/os/freebsd/bpf.rs
+++ b/src/os/freebsd/bpf.rs
@@ -86,7 +86,7 @@ pub fn bpf_open_device(debug: &Verbose) -> io::Result<(i32)> {
         let res = unsafe { libc::open(&buf as *const i8, libc::O_RDWR) };
 
         // check returned value
-        // if negative, an error occured, continue
+        // if negative, an error occurred, continue
         // if positive, return the file descriptor
         if res >= 0 {
             return Ok(res);

--- a/src/os/linux/libnl.rs
+++ b/src/os/linux/libnl.rs
@@ -548,7 +548,7 @@ pub fn set_ip_route(rt: &IntIpRoute) -> io::Result<()> {
         -6 => (),  // route already exists
         -12 => (), // route not found
         r if r < 0 => return Err(io::Error::last_os_error()),
-        _ => (), // no error occured
+        _ => (), // no error occurred
     }
 
     // free nlroute

--- a/src/vrouter.rs
+++ b/src/vrouter.rs
@@ -794,7 +794,7 @@ impl VirtualRouter {
                     Operation::Rem => None,
                 }
             }
-            // catched an error while setting up the macvlan interface
+            // caught an error while setting up the macvlan interface
             Err(e) => {
                 eprintln!(
                 "error(macvlan): cannot perform operation {:?} on macvlan interface (master if: {:?}): {}",


### PR DESCRIPTION
Common spelling errors being picked up by packaging tooling, which this commit patches up. Just routine cleanup, nothing crazy here.